### PR TITLE
Add .gitattributes to allow for language detection in /demo directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+demos/** linguist-documentation=false


### PR DESCRIPTION
Currently, the custom-questions-skeleton repo has no language detection because all files are in a directory called 'demo' that GitHub's language detection software [Linguist](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#using-gitattributes) ignores by default:

![image showing no languages in the custom-questions-skeleton repo](https://github.com/Learnosity/custom-questions-skeleton/assets/154474514/adad314b-fa9a-4cb0-b713-d63e3e223100)

This PR marks that directory as non-documentation so that Linguist will scan the folder and detect the languages within, making it easier for developers to understand which languages are used in the repo at a glance.

See  [this fork](https://github.com/andela-technology/custom-questions-skeleton) to see it in action:

![image showing languages detected on the repo](https://github.com/Learnosity/custom-questions-skeleton/assets/154474514/7f3f8542-110b-42b9-aa91-e293b03032e2)

Note that languages may take a bit of time to detect and/or require a change to a code file within the 'demos' directory in order to run.