### PR TITLE
[BUG] Fix mismatch in actual and valid responses for box & whisker plot

### DIFF
--- a/demos/box-and-whisker/src/question/components/boxAndWhisker.js
+++ b/demos/box-and-whisker/src/question/components/boxAndWhisker.js
@@ -309,7 +309,7 @@ export default class BoxAndWhisker {
 
                 d3.select(this).attr('cx', originalX);
                 line.attr('x1', originalX).attr('x2', originalX);
-                text.attr('x', originalX).text(round(self.pxToUnit(originalX)));
+                text.attr('x', originalX).text(self.roundToNearestStep(self.pxToUnit(originalX)));
 
                 onDrag({
                     event,
@@ -349,14 +349,21 @@ export default class BoxAndWhisker {
         };
 
         this.response.value = {
-            min: round(pxToUnit(getHandlerX(minHandler))),
-            max: round(pxToUnit(getHandlerX(maxHandler))),
-            quartile_1: round(pxToUnit(getHandlerX(q1Handler))),
-            median: round(pxToUnit(getHandlerX(medianHandler))),
-            quartile_3: round(pxToUnit(getHandlerX(q3Handler)))
+            min: this.roundToNearestStep(pxToUnit(getHandlerX(minHandler))),
+            max: this.roundToNearestStep(pxToUnit(getHandlerX(maxHandler))),
+            quartile_1: this.roundToNearestStep(pxToUnit(getHandlerX(q1Handler))),
+            median: this.roundToNearestStep(pxToUnit(getHandlerX(medianHandler))),
+            quartile_3: this.roundToNearestStep(pxToUnit(getHandlerX(q3Handler)))
         };
 
         this.triggerEvent('onChange', this.response);
+    }
+
+    roundToNearestStep(num) {
+        const step = this.get('step') || 1;
+        const stepFactor = 1 / step;
+        
+        return Math.round(num * stepFactor) / stepFactor;
     }
 
     get(key) {

--- a/demos/box-and-whisker/webpack.config.js
+++ b/demos/box-and-whisker/webpack.config.js
@@ -13,7 +13,8 @@ module.exports = {
     },
     output: {
         path: distDir,
-        filename: '[name].js'
+        filename: '[name].js',
+        hashFunction: 'xxhash64'
     },
     plugins: [
         new MiniCssExtractPlugin({


### PR DESCRIPTION
This commit involves -
1. rounding the actual response values to nearest step value to fix the issue
2. a change in `webpack.config.js` to avoid build error - `[webpack-cli] Error: error:0308010C:digital envelope routines::unsupported` during `yarn dev`

[LRN-43669](https://learnosity.atlassian.net/browse/LRN-43669)

[LRN-43669]: https://learnosity.atlassian.net/browse/LRN-43669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ