### PR TITLE
[UPDATE] Change properties to attributes for QE demos

### DIFF
--- a/demos/box-and-whisker/authoring.php
+++ b/demos/box-and-whisker/authoring.php
@@ -59,7 +59,7 @@ $request = '
               "version": "v1.0.0",
               "editor_schema": {
                 "hidden_question": false,
-                "properties": {
+                "attributes": {
                   "line_min": {
                     "type": "number",
                     "name": "Minimum range",

--- a/demos/clock/question_editor_init_options.json
+++ b/demos/clock/question_editor_init_options.json
@@ -43,7 +43,7 @@
         "version": "v1.0.0",
         "editor_schema": {
           "hidden_question": false,
-          "properties": {
+          "attributes": {
               "instant_feedback": {
                 "name": "Check answer button",
                 "description": "Enables the Check Answer button underneath the question, which will provide the student with instant feedback on their response(s).",

--- a/demos/custom-feature-skeleton/question_editor_init_options.json
+++ b/demos/custom-feature-skeleton/question_editor_init_options.json
@@ -9,7 +9,7 @@
          "editor_layout": "/dist/authoring_custom_layout.html",
          "editor_schema": {
             "hidden_question": false,
-            "properties": {
+            "attributes": {
                "example_custom_property": {
                   "name": "Text to be displayed:",
                   "description": "The text to appear on the custom feature",

--- a/demos/custom-question-skeleton/question_editor_init_options.json
+++ b/demos/custom-question-skeleton/question_editor_init_options.json
@@ -32,7 +32,7 @@
         "version": "v1.0.0",
         "editor_schema": {
           "hidden_question": false,
-          "properties": {
+          "attributes": {
               "instant_feedback": {
                 "name": "Check answer button",
                 "description": "Enables the Check Answer button underneath the question, which will provide the student with instant feedback on their response(s).",

--- a/demos/piano/authoring.php
+++ b/demos/piano/authoring.php
@@ -49,7 +49,7 @@ $request = '
               "version": "v1.0.0",
               "editor_schema": {
                 "hidden_question": false,
-                "properties": {
+                "attributes": {
                     "instant_feedback": {
                       "name": "Check answer button",
                       "description": "Enables the Check Answer button underneath the question, which will provide the student with instant feedback on their response(s).",

--- a/demos/simple-input-react/authoring.php
+++ b/demos/simple-input-react/authoring.php
@@ -45,7 +45,7 @@ $request = '
               "version": "v1.0.0",
               "editor_schema": {
                 "hidden_question": false,
-                "properties": {
+                "attributes": {
                   "max_length": {
                     "default": 20,
                     "description": "Maximum number of characters that can be entered in the field. Maximum value is 250. For longer questions use longtext type.",
@@ -57,7 +57,10 @@ $request = '
                       "description": "Maximum number of characters that can be entered in the text entry area. Maximum 250 characters."
                     }
                   },
-                  "valid_response": {
+                  "valid_response": {,
+                    "name": "Set correct answer(s)",
+                    "description": "In this section, configure the correct answer(s) for the question.",
+                    "type": "object"
                     "attributes": {
                       "value": {
                         "name": "Correct Answer",
@@ -79,10 +82,7 @@ $request = '
                         "required": true,
                         "default": 1
                       }
-                    },
-                    "name": "Set correct answer(s)",
-                    "description": "In this section, configure the correct answer(s) for the question.",
-                    "type": "object"
+                    }
                   },
                   "instant_feedback": {
                     "name": "Check answer button",


### PR DESCRIPTION
Whilst both are supported, update use of custom question key "properties" to be "attributes" to align with our [documentation](https://help.learnosity.com/hc/en-us/articles/21278981402013-custom-question-types-editor-schema-attributes-Initialization-Question-Editor-API)