### PR TITLE
LRN-51497: Fix validation UI not rendering correctly in review state

### DIFF
--- a/demos/box-and-whisker/src/question/utils/shapeHelper.js
+++ b/demos/box-and-whisker/src/question/utils/shapeHelper.js
@@ -1,137 +1,144 @@
-import { each } from 'lodash';
-import { AXIS_Y, HANDLER, MARGIN, STATES, ICONS } from '../constants';
-import { getClassName, getShapeWidth, getShapeX } from './dom';
-import * as d3 from 'd3';
+import { each } from "lodash";
+import { AXIS_Y, HANDLER, MARGIN, STATES, ICONS } from "../constants";
+import { getClassName, getShapeWidth, getShapeX } from "./dom";
+import * as d3 from "d3";
 
 const isEvenNumber = (number) => number % 2 === 0;
 
 export const drawDomainAxis = (parentElement, width, min, max) => {
-    const getWidth = () => {
-        const width = width || 600;
+  const getWidth = () => {
+    const w = width || 600;
 
-        return width - MARGIN.LEFT - MARGIN.RIGHT;
-    };
-    const minLine = () => {
-        return isEvenNumber(min) ? min - 1 : min;
-    };
-    const maxLine = () => {
-        return isEvenNumber(max) ? max + 1 : max;
-    };
-    const createArrowDef = (arrowId, arrowPoints) => {
-        parentElement
-            .select('defs')
-            .append('marker')
-            .attr('id', arrowId)
-            .attr('refX', 10)
-            .attr('refY', 3.5)
-            .attr('markerWidth', 10)
-            .attr('markerHeight', 7)
-            .append('polygon')
-            .attr('points', arrowPoints)
-            .attr('fill', 'black');
-    };
+    return w - MARGIN.LEFT - MARGIN.RIGHT;
+  };
+  const minLine = () => {
+    return isEvenNumber(min) ? min - 1 : min;
+  };
+  const maxLine = () => {
+    return isEvenNumber(max) ? max + 1 : max;
+  };
+  const createArrowDef = (arrowId, arrowPoints) => {
+    parentElement
+      .select("defs")
+      .append("marker")
+      .attr("id", arrowId)
+      .attr("refX", 10)
+      .attr("refY", 3.5)
+      .attr("markerWidth", 10)
+      .attr("markerHeight", 7)
+      .append("polygon")
+      .attr("points", arrowPoints)
+      .attr("fill", "black");
+  };
 
-    const scaleX = d3
-        .scaleLinear()
-        // Make sure the first & last numbers of the line are Odd number
-        .domain([minLine(), maxLine()])
-        .range([MARGIN.LEFT, getWidth()]);
+  const scaleX = d3
+    .scaleLinear()
+    // Make sure the first & last numbers of the line are Odd number
+    .domain([minLine(), maxLine()])
+    .range([MARGIN.LEFT, getWidth()]);
 
-    createArrowDef('arrowhead-left', '10 0, 10 7, 0 3.5');
-    createArrowDef('arrowhead-right', '0 0, 10 3.5, 0 7');
+  createArrowDef("arrowhead-left", "10 0, 10 7, 0 3.5");
+  createArrowDef("arrowhead-right", "0 0, 10 3.5, 0 7");
 
-    const xAxis = parentElement
-        .append('g')
-        .attr('class', getClassName('axis'))
-        .attr('transform', `translate(0,${AXIS_Y})`)      // This controls the vertical position of the Axis
-        .call(d3.axisBottom(scaleX).tickSizeOuter(0));
+  const xAxis = parentElement
+    .append("g")
+    .attr("class", getClassName("axis"))
+    .attr("transform", `translate(0,${AXIS_Y})`) // This controls the vertical position of the Axis
+    .call(d3.axisBottom(scaleX).tickSizeOuter(0));
 
-    xAxis.select('path.domain')
-        .attr('marker-end', 'url(#arrowhead-right)')
-        .attr('marker-start', 'url(#arrowhead-left)')
-    ;
-    
-    return scaleX;
-} 
+  xAxis
+    .select("path.domain")
+    .attr("marker-end", "url(#arrowhead-right)")
+    .attr("marker-start", "url(#arrowhead-left)");
+
+  return scaleX;
+};
 
 export const drawLine = (parent, x1, y1, x2, y2) => {
-    return parent.append('line')
-        .attr('x1', x1)
-        .attr('y1', y1)
-        .attr('x2', x2)
-        .attr('y2', y2)
-        .attr('stroke', 'currentColor')
-        ;
+  return parent
+    .append("line")
+    .attr("x1", x1)
+    .attr("y1", y1)
+    .attr("x2", x2)
+    .attr("y2", y2)
+    .attr("stroke", "currentColor");
 };
 
 export const drawRect = (parent, x, y, width, height) => {
-    return parent.append('rect')
-        .attr('x', x)
-        .attr('y', y)
-        .attr('width', width)
-        .attr('height', height)
-    ;
+  return parent
+    .append("rect")
+    .attr("x", x)
+    .attr("y", y)
+    .attr("width", width)
+    .attr("height", height);
 };
 
 export const drawText = (parent, x, y, text) => {
-    return parent.append('text')
-        .attr('x', x)
-        .attr('y', y)
-        .attr('text-anchor', 'middle')
-        .text(text);
+  return parent
+    .append("text")
+    .attr("x", x)
+    .attr("y", y)
+    .attr("text-anchor", "middle")
+    .text(text);
 };
 
 export const drawHandler = (parent, x1, y1, x2, y2, textContent) => {
-    const { RADIUS, ICON_HEIGHT, TEXT_GAP } = HANDLER;
-    const line = drawLine(parent, x1, y1, x2, y2)
-        .attr('class', getClassName('handler-line'));
-    const text = drawText(parent, x1, y1 - TEXT_GAP, textContent)
-        .attr('class', getClassName('handler-text'));
-    const handler = parent.append('circle')
-        .attr('cx', x1)
-        .attr('cy', y2 - y1 + MARGIN.TOP)
-        .attr('r', RADIUS)
-        .attr('class', getClassName('handler-point'))
-        ;
+  const { RADIUS, ICON_HEIGHT, TEXT_GAP } = HANDLER;
+  const line = drawLine(parent, x1, y1, x2, y2).attr(
+    "class",
+    getClassName("handler-line"),
+  );
+  const text = drawText(parent, x1, y1 - TEXT_GAP, textContent).attr(
+    "class",
+    getClassName("handler-text"),
+  );
+  const handler = parent
+    .append("circle")
+    .attr("cx", x1)
+    .attr("cy", y2 - y1 + MARGIN.TOP)
+    .attr("r", RADIUS)
+    .attr("class", getClassName("handler-point"));
+  return {
+    line,
+    text,
+    handler,
+    setState(state) {
+      const iconClassName = getClassName("validation-icon");
+      const classNames = {
+        [getClassName("correct")]: state === STATES.CORRECT,
+        [getClassName("incorrect")]: state === STATES.INCORRECT,
+      };
+      const shouldShowValidationUI = [
+        STATES.CORRECT,
+        STATES.INCORRECT,
+      ].includes(state);
+      let icon;
 
-    return {
-        line,
-        text,
-        handler,
-        setState(state) {
-            const iconClassName = getClassName('validation-icon');
-            const classNames = {
-                [getClassName('correct')]: state === STATES.CORRECT,
-                [getClassName('incorrect')]: state === STATES.INCORRECT
-            };
-            const shouldShowValidationUI = [STATES.CORRECT, STATES.INCORRECT].includes(state);
-            let icon;
+      if (shouldShowValidationUI) {
+        const x = getShapeX(text) + Math.round(getShapeWidth(text) / 2);
+        const y = MARGIN.TOP - ICON_HEIGHT;
 
-            if (shouldShowValidationUI) {
-                const x = getShapeX(text) + Math.round(getShapeWidth(text) / 2);
-                const y = MARGIN.TOP - ICON_HEIGHT;
+        icon = parent
+          .append("path")
+          .attr("d", ICONS[state])
+          .attr("class", iconClassName)
+          .attr("transform", `translate(${x}, ${y})`);
+      }
 
-                icon = parent
-                    .append('path')
-                    .attr('d', ICONS[state])
-                    .attr('class', iconClassName)
-                    .attr('transform', `translate(${x}, ${y})`);
-            }
+      each(classNames, (value, className) => {
+        line.classed(className, value);
+        text.classed(className, value);
+        handler.classed(className, value);
 
-            each(classNames, (value, className) => {
-                line.classed(className, value);
-                text.classed(className, value);
-                handler.classed(className, value);
-
-                if (icon) {
-                    icon.classed(className, value);
-                }
-            });
-
-            // clear state
-            if (!shouldShowValidationUI) {
-                parent.select(`.${iconClassName}`).remove();
-            }
+        if (icon) {
+          icon.classed(className, value);
         }
-    };
+      });
+
+      // clear state
+      if (!shouldShowValidationUI) {
+        parent.select(`.${iconClassName}`).remove();
+      }
+    },
+  };
 };

--- a/demos/custom-dynamic-try-again/assessment.php
+++ b/demos/custom-dynamic-try-again/assessment.php
@@ -23,7 +23,7 @@ $signedRequest = signAssessmentRequest($requestData);
 <head>
     <meta charset="UTF-8">
     <title>Custom Question — Dynamic Content Try Again</title>
-    <script src="//questions.learnosity.com"></script>
+    <script src="//questions.dev.learnosity.com"></script>
     <style>
         <?php echo(file_get_contents('../sharedStyle.css')); ?>
 

--- a/demos/custom-dynamic-try-again/src/question/index.js
+++ b/demos/custom-dynamic-try-again/src/question/index.js
@@ -121,6 +121,10 @@ export default class UnitConverterQuestion {
 
         facade.on('dynamicContent:changed', ({ question, response }) => {
             this.renderCard(question, response);
+
+            if (this.init.state === 'review') {
+                this.renderValidationUI();
+            }
         });
     }
 
@@ -165,25 +169,34 @@ export default class UnitConverterQuestion {
 
         // 'validate' fires when Check Answer is clicked or facade.validate() is called.
         events.on('validate', options => {
-            const isValid = facade.isValid();
-            const responseInputEl = el.querySelector('.lrn_response_input');
-
-            responseInputEl.classList.remove(`${PREFIX}--correct`, `${PREFIX}--incorrect`);
-            responseInputEl.classList.add(isValid ? `${PREFIX}--correct` : `${PREFIX}--incorrect`);
-
-            if (!isValid && options.showCorrectAnswers && this.suggestedAnswersList) {
-                const validValue =
-                    this.currentQuestion.validation &&
-                    this.currentQuestion.validation.valid_response &&
-                    this.currentQuestion.validation.valid_response.value;
-
-                if (validValue !== undefined) {
-                    this.suggestedAnswersList.setAnswers(
-                        `${validValue} ${this.currentQuestion.toUnit}`
-                    );
-                }
-            }
+            // cache the showCorrectAnswers value for use in renderValidationUI()
+            this._showCorrectAnswers = options.showCorrectAnswers;
+            this.renderValidationUI();
         });
+    }
+
+    renderValidationUI() {
+        const { el, events, init } = this;
+        const facade = init.getFacade();
+        const isValid = facade.isValid();
+        const responseInputEl = el.querySelector('.lrn_response_input');
+        const shouldShowCorrectAnswers = this._showCorrectAnswers;
+
+        responseInputEl.classList.remove(`${PREFIX}--correct`, `${PREFIX}--incorrect`);
+        responseInputEl.classList.add(isValid ? `${PREFIX}--correct` : `${PREFIX}--incorrect`);
+
+        if (!isValid && shouldShowCorrectAnswers && this.suggestedAnswersList) {
+            const validValue =
+                this.currentQuestion.validation &&
+                this.currentQuestion.validation.valid_response &&
+                this.currentQuestion.validation.valid_response.value;
+
+            if (validValue !== undefined) {
+                this.suggestedAnswersList.setAnswers(
+                    `${validValue} ${this.currentQuestion.toUnit}`
+                );
+            }
+        }
     }
 
     clearValidationUI() {


### PR DESCRIPTION
#### What's this PR do?
Fixes the `custom-dynamic-try-again` demo question so validation UI renders correctly in review state when navigating between attempts.

- Extracts `renderValidationUI()` so it can be called from both the `validate` event handler and the `dynamicContent:changed` handler
- Caches `showCorrectAnswers` from the `validate` event so subsequent `renderValidationUI()` calls on attempt navigation continue to use it
- Calls `renderValidationUI()` in review state after each `dynamicContent:changed` event, so correct/incorrect state is shown as the student navigates through stored attempts

#### Any background context you want to provide?
This is part of the LRN-51480 / LRN-51497 work adding dynamic content try-again support for custom questions. The review state navigation flow exposed that the widget was not re-rendering its validation UI after the platform fired `dynamicContent:changed` on attempt navigation.

#### Any relevant Jira ticket(s) to provide?
https://learnosity.atlassian.net/browse/LRN-51497